### PR TITLE
[10] Remove the jboss-logging dependency. General updates to the POM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
   ~ SPDX-License-Identifier: Apache-2.0
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -25,7 +25,7 @@
     <licenses>
         <license>
             <name>Apache License 2.0</name>
-            <url>http://repository.jboss.org/licenses/apache-2.0.txt</url>
+            <url>https://repository.jboss.org/licenses/apache-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -44,9 +44,9 @@
         <wildfly.launcher.bootable.jar>${basedir}/target/${wildfly.bootable.jar.name}</wildfly.launcher.bootable.jar>
 
         <!-- Base on SE 11. -->
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
+        <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
 
         <!-- Dependency versions -->
 
@@ -56,19 +56,23 @@
 
         <!-- Production/build time dependencies-->
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>3.0.2.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>3.0.3.Final</version.org.jboss.logging.jboss-logging-tools>
         <!-- Test dependencies -->
         <version.org.jboss.modules.jboss-modules>2.1.5.Final</version.org.jboss.modules.jboss-modules>
         <version.org.junit>5.11.3</version.org.junit>
 
         <!-- Test properties -->
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
+        <test.modules.path>${project.build.directory}/test-modules</test.modules.path>
 
         <!-- Provisioning properties for tests -->
         <jboss.home>${project.build.directory}/server</jboss.home>
 
         <wildfly.feature.pack.groupId>org.wildfly</wildfly.feature.pack.groupId>
         <wildfly.feature.pack.artifactId>wildfly-ee-galleon-pack</wildfly.feature.pack.artifactId>
+        <!-- Keep default at WildFly 34 as WildFly 35+ requires Java 17. Once this project requires Java 17, this
+             property should be set to an empty property.
+         -->
         <wildfly.feature.pack.version>34.0.0.Final</wildfly.feature.pack.version>
 
         <wildfly.channel.manifest.groupId>org.wildfly.channels</wildfly.channel.manifest.groupId>
@@ -92,23 +96,7 @@
         <!-- This dependency is only needed at compile time and requires no runtime dependencies -->
         <dependency>
             <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>${version.org.jboss.logging.jboss-logging}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
-            <version>${version.org.jboss.logging.jboss-logging-tools}</version>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
             <version>${version.org.jboss.logging.jboss-logging-tools}</version>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
                   projects that depend on this project.-->
@@ -148,14 +136,20 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.jboss.logging</groupId>
+                                <artifactId>jboss-logging-processor</artifactId>
+                                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                            </path>
+                        </annotationProcessorPaths>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
                     <configuration>
-                        <archive>
-                            <manifestEntries>
-                                <Scm-Url>${wildfly.launcher.scm.url}</Scm-Url>
-                            </manifestEntries>
-                        </archive>
                         <!-- Do not package the generated logging properties as the generated binaries will be packaged -->
                         <!-- These files are not required at runtime -->
                         <excludes>
@@ -166,7 +160,6 @@
                 </plugin>
                 <!-- Checkstyle -->
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <executions>
                         <execution>
@@ -196,7 +189,6 @@
 
                 <!-- Require Java 11 for deploying -->
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <executions>
                         <execution>
@@ -219,7 +211,6 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
             <!-- Create a fake WildFly directory -->
@@ -239,7 +230,7 @@
                                     <artifactId>jboss-modules</artifactId>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <outputDirectory>${wildfly.launcher.home}</outputDirectory>
+                                    <outputDirectory>${test.modules.path}</outputDirectory>
                                     <destFileName>jboss-modules.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
@@ -248,12 +239,11 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
                         <jboss.home>${jboss.home}</jboss.home>
-                        <wildfly.launcher.home>${wildfly.launcher.home}</wildfly.launcher.home>
+                        <wildfly.launcher.home>${test.modules.path}</wildfly.launcher.home>
                         <wildfly.launcher.bootable.jar>${wildfly.launcher.bootable.jar}</wildfly.launcher.bootable.jar>
                     </systemPropertyVariables>
                 </configuration>


### PR DESCRIPTION
resolves #10 

This PR will fail until the 3.0.3.Final release of the JBoss Logging Tools has been synchronized to Maven Central.