### PR TITLE
[86] Do not add the -Djava.security.manager=allow system property unl…

### DIFF
--- a/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -753,7 +753,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
                 }
             }
         }
-        if (hostControllerJvm.enhancedSecurityManagerAvailable()) {
+        if (useSecurityManager() && hostControllerJvm.enhancedSecurityManagerAvailable()) {
             cmd.add(SECURITY_MANAGER_PROP_WITH_ALLOW_VALUE);
         }
 


### PR DESCRIPTION
…ess the security manager is enabled on the host controller.

resolves #38 