### PR TITLE
WildFly 40+ defaults to EE11 which does not support the security mana…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
         <wildfly.channel.manifest.artifactId>wildfly-ee</wildfly.channel.manifest.artifactId>
         <wildfly.channel.manifest.version>${wildfly.feature.pack.version}</wildfly.channel.manifest.version>
 
+        <!-- Used to enabled/disable testing the boot with the security manager enabled. EE 11 does not work with the
+             security manager enabled. By default, WildFly 40+ is EE 11.
+         -->
+        <wildfly.security.manager>false</wildfly.security.manager>
+
         <!-- maven-release-plugin configuration -->
         <autoVersionSubmodules>true</autoVersionSubmodules>
         <releaseProfiles>central-release</releaseProfiles>
@@ -260,6 +265,7 @@
                         <jboss.home>${jboss.home}</jboss.home>
                         <wildfly.launcher.home>${test.modules.path}</wildfly.launcher.home>
                         <wildfly.launcher.bootable.jar>${wildfly.launcher.bootable.jar}</wildfly.launcher.bootable.jar>
+                        <wildfly.security.manager>${wildfly.security.manager}</wildfly.security.manager>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>
@@ -363,6 +369,7 @@
             </activation>
             <properties>
                 <wildfly.feature.pack.version>34.0.1.Final</wildfly.feature.pack.version>
+                <wildfly.security.manager>true</wildfly.security.manager>
             </properties>
         </profile>
     </profiles>

--- a/src/test/java/org/wildfly/core/launcher/ServerLauncherTest.java
+++ b/src/test/java/org/wildfly/core/launcher/ServerLauncherTest.java
@@ -37,6 +37,7 @@ import org.wildfly.plugin.tools.server.ServerManager;
 class ServerLauncherTest {
     private static final Path JBOSS_HOME = Path.of(System.getProperty("jboss.home"));
     private static final Path BOOTABLE_JAR = Path.of(System.getProperty("wildfly.launcher.bootable.jar"));
+    private static final boolean TEST_SECURITY_MANAGER = Boolean.parseBoolean(System.getProperty("wildfly.security.manager"));
 
 
     @TestTemplate
@@ -91,7 +92,7 @@ class ServerLauncherTest {
             invocationContexts.add(createTestContext("Standalone", StandaloneCommandBuilder.of(JBOSS_HOME), 60L));
             invocationContexts.add(createTestContext("Domain", DomainCommandBuilder.of(JBOSS_HOME), 60L));
             invocationContexts.add(createTestContext("Bootable JAR", BootableJarCommandBuilder.of(BOOTABLE_JAR), 60L));
-            if (Jvm.current().isSecurityManagerSupported()) {
+            if (TEST_SECURITY_MANAGER && Jvm.current().isSecurityManagerSupported()) {
                 invocationContexts.add(createTestContext("Standalone With Security Manager", StandaloneCommandBuilder.of(JBOSS_HOME).setUseSecurityManager(true), 60L));
                 invocationContexts.add(createTestContext("Domain With Security Manager", DomainCommandBuilder.of(JBOSS_HOME).setUseSecurityManager(true), 60L));
                 invocationContexts.add(createTestContext("Bootable JAR With Security Manager", BootableJarCommandBuilder.of(BOOTABLE_JAR).addServerArgument("-secmgr"), 60L));


### PR DESCRIPTION
…ger. Disable the security manager by default, but allow it to be enabled via the wildfly.security.manager system property.